### PR TITLE
feat: upgrade to azurerm v4 and azuread v3

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.72"
+      version = "~> 4.0"
     }
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.41"
+      version = "~> 3.0"
     }
   }
 


### PR DESCRIPTION
All new workloads should use the latest version of the azurerm and azuread providers as default 