### PR TITLE
fix: changed from application_id to client_id

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -41,8 +41,8 @@ variable "groups" {
 variable "applications" {
   description = "Applications provisioned with Station"
   type = map(object({
-    application_id = string
-    object_id      = string
+    client_id = string
+    object_id = string
   }))
   default = {}
 }


### PR DESCRIPTION
Changed the template to use the `client_id`  as this was changed in station [v1.4.0](https://github.com/blinqas/station/releases/tag/v1.4.0)